### PR TITLE
[TASK] Define permissions on workflow level

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   cgl:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   # Job: Create release
   release:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   tests:
     name: Tests (PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.dependencies }} dependencies)


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to explicitly define permissions for better security and functionality. The changes ensure that each workflow has the appropriate level of access to the repository.

GitHub Actions workflow updates:

* [`.github/workflows/cgl.yaml`](diffhunk://#diff-e67ee0bda8360eba38abf2112c768f6e3ae49653d41da3501f64632426e982eaR10-R11): Added `permissions: read-all` to grant read-only access for this workflow.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR7-R9): Added `permissions` block with `contents: write` to allow the release workflow to write to the repository.
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R10-R11): Added `permissions: read-all` to grant read-only access for the tests workflow.