### PR TITLE
[FEATURE] Implement context-specific configuration path retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ $systemConfigLoader->loadCached();
 
 The [`Helhum\ConfigLoader\Reader\PhpFileReader`][2] receives lowest priority when
 loading system configuration. It resolves system configuration from a context-specific
-file path within the `app/config/environment` directory. Each file must return an array
-with additional system configuration values.
+file path within the `app/config/environment` directory. The default directory path can be
+overwritten with an environment variable `CONTEXT_CONFIGURATION_PATH`. Each file must return an
+array with additional system configuration values.
 
 **Example:**
 

--- a/src/Loader/SystemConfigurationLoader.php
+++ b/src/Loader/SystemConfigurationLoader.php
@@ -340,7 +340,24 @@ final readonly class SystemConfigurationLoader implements CacheableConfiguration
         $rootPath = Environment::getProjectPath();
         $context = Environment::getContext();
 
-        return sprintf('%s/%s/%s.php', $rootPath, self::CONTEXT_CONFIGURATION_PATH, (string)$context);
+        return sprintf('%s/%s/%s.php', $rootPath, $this->getContextConfigurationPath(), (string)$context);
+    }
+
+    /**
+     * Get path to context configuration.
+     *
+     * Returns the path to the context configuration directory. This is used
+     * to load context-specific configuration files.
+     *
+     * @return string Path to context configuration directory
+     */
+    private function getContextConfigurationPath(): string
+    {
+        if (is_string(getenv('CONTEXT_CONFIGURATION_PATH'))) {
+            return (string)getenv('CONTEXT_CONFIGURATION_PATH');
+        }
+
+        return self::CONTEXT_CONFIGURATION_PATH;
     }
 
     /**

--- a/src/Loader/SystemConfigurationLoader.php
+++ b/src/Loader/SystemConfigurationLoader.php
@@ -353,8 +353,10 @@ final readonly class SystemConfigurationLoader implements CacheableConfiguration
      */
     private function getContextConfigurationPath(): string
     {
-        if (is_string(getenv('CONTEXT_CONFIGURATION_PATH'))) {
-            return (string)getenv('CONTEXT_CONFIGURATION_PATH');
+        $contextConfigurationPath = (string)getenv('CONTEXT_CONFIGURATION_PATH');
+
+        if ($contextConfigurationPath !== '') {
+            return $contextConfigurationPath;
         }
 
         return self::CONTEXT_CONFIGURATION_PATH;

--- a/tests/src/Loader/SystemConfigurationLoaderTest.php
+++ b/tests/src/Loader/SystemConfigurationLoaderTest.php
@@ -220,6 +220,33 @@ final class SystemConfigurationLoaderTest extends TestCase
         $this->unsetEnvironmentVariablesConfiguration();
     }
 
+    #[Test]
+    public function getContextConfigurationPathReturnsDefaultPath(): void
+    {
+        $reflection = new \ReflectionObject($this->subject);
+        $method = $reflection->getMethod('getContextConfigurationPath');
+
+        $result = $method->invoke($this->subject);
+
+        self::assertSame('app/config/environment', $result);
+    }
+
+    #[Test]
+    public function getContextConfigurationPathReturnsCustomPathFromEnvironment(): void
+    {
+        $customPath = 'custom/config/path';
+        putenv('CONTEXT_CONFIGURATION_PATH=' . $customPath);
+
+        $reflection = new \ReflectionObject($this->subject);
+        $method = $reflection->getMethod('getContextConfigurationPath');
+
+        $result = $method->invoke($this->subject);
+
+        self::assertSame($customPath, $result);
+
+        putenv('CONTEXT_CONFIGURATION_PATH');
+    }
+
     /**
      * @return ConfigReaderInterface[]
      */


### PR DESCRIPTION
This PR is related to #20 and enhances the `SystemConfigurationLoader` to support a custom context-specific configuration path with an optional environment variable `CONTEXT_CONFIGURATION_PATH`, allowing for more flexible configuration loading based on the current application context.