### PR TITLE
[FEATURE] Allow bridging additional configuration sections to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ must be prefixed by `TYPO3` and each configuration key must be separated by `__`
 * Environment variable: `TYPO3__MAIL__transport_smtp_server`
 * Configuration path: `$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server']`
 
+## Bridging configuration back to environment variables
+
+Once all readers are merged into `$GLOBALS['TYPO3_CONF_VARS']`, the `CMS` section is
+transformed back into environment variables, prefixed by `PHP_`, e.g. for use in
+`Configuration/Services.yaml` via `%env(PHP_CMS_BASE_1)%`.
+
+Additional top-level sections can be bridged the same way by passing them to
+`SystemConfigurationLoader::__construct()`:
+
+```php
+$systemConfigLoader = new CPSIT\Typo3ConfigLoader\Loader\SystemConfigurationLoader(['CMS', 'API', 'APP']);
+$systemConfigLoader->loadCached();
+```
+
+> [!WARNING]
+> Only bridge sections that are safe to expose as environment variables. Environment
+> variables are readable through `phpinfo()`, exception/log dumps of `$_ENV`, child
+> process inheritance, and `docker inspect`. Do not bridge sections that may contain
+> secrets, e.g. `DB`, `BE`, or extension configuration holding API keys.
+
 ## 💡 Custom loaders
 
 In case this library does not fulfill all your requirements, you are free to extend

--- a/src/Loader/SystemConfigurationLoader.php
+++ b/src/Loader/SystemConfigurationLoader.php
@@ -57,7 +57,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * All loaders provide configuration for `$GLOBALS['TYPO3_CONF_VARS']`. Additionally,
  * all configuration within `CMS` is transformed to environment variables, prefixed by
- * {@see self::ENV_PREFIX}.
+ * {@see self::ENV_PREFIX}. Additional top-level sections can be transformed the same
+ * way by passing them to {@see self::__construct()}.
  *
  * Example configuration (YAML):
  *
@@ -80,15 +81,27 @@ final readonly class SystemConfigurationLoader implements CacheableConfiguration
     private const CONTEXT_CONFIGURATION_PATH = 'app/config/environment';
     private const ENV_PREFIX = 'PHP_';
     private const ENV_DELIMITER = '_';
+    private const DEFAULT_ENVIRONMENT_SECTIONS = ['CMS'];
 
     /**
      * @var ConfigReaderInterface[]
      */
     private array $readers;
 
-    public function __construct()
+    /**
+     * @var non-empty-string[]
+     */
+    private array $environmentSections;
+
+    /**
+     * @param non-empty-string[] $environmentSections Top-level `$GLOBALS['TYPO3_CONF_VARS']`
+     *                                                 sections that are transformed to
+     *                                                 environment variables, defaults to `CMS`
+     */
+    public function __construct(array $environmentSections = self::DEFAULT_ENVIRONMENT_SECTIONS)
     {
         $this->readers = $this->initializeReaders();
+        $this->environmentSections = $environmentSections;
     }
 
     /**
@@ -149,9 +162,11 @@ final readonly class SystemConfigurationLoader implements CacheableConfiguration
 
         $GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive($globalConfig, $data);
 
-        // Create CMS specific environment variables
-        if (is_array($cmsConfig = $GLOBALS['TYPO3_CONF_VARS']['CMS'] ?? null)) {
-            $this->createEnvironmentVariables($cmsConfig, 'CMS');
+        // Create environment variables for all configured sections
+        foreach ($this->environmentSections as $section) {
+            if (is_array($sectionConfig = $GLOBALS['TYPO3_CONF_VARS'][$section] ?? null)) {
+                $this->createEnvironmentVariables($sectionConfig, $section);
+            }
         }
     }
 

--- a/src/Loader/SystemConfigurationLoader.php
+++ b/src/Loader/SystemConfigurationLoader.php
@@ -89,19 +89,13 @@ final readonly class SystemConfigurationLoader implements CacheableConfiguration
     private array $readers;
 
     /**
-     * @var non-empty-string[]
-     */
-    private array $environmentSections;
-
-    /**
      * @param non-empty-string[] $environmentSections Top-level `$GLOBALS['TYPO3_CONF_VARS']`
      *                                                 sections that are transformed to
      *                                                 environment variables, defaults to `CMS`
      */
-    public function __construct(array $environmentSections = self::DEFAULT_ENVIRONMENT_SECTIONS)
+    public function __construct(private array $environmentSections = self::DEFAULT_ENVIRONMENT_SECTIONS)
     {
         $this->readers = $this->initializeReaders();
-        $this->environmentSections = $environmentSections;
     }
 
     /**

--- a/tests/src/Loader/SystemConfigurationLoaderTest.php
+++ b/tests/src/Loader/SystemConfigurationLoaderTest.php
@@ -77,6 +77,20 @@ final class SystemConfigurationLoaderTest extends TestCase
     }
 
     #[Test]
+    public function constructorDefaultsToCmsEnvironmentSection(): void
+    {
+        self::assertSame(['CMS'], $this->getEnvironmentSectionsFromSubject($this->subject));
+    }
+
+    #[Test]
+    public function constructorAcceptsCustomEnvironmentSections(): void
+    {
+        $subject = new SystemConfigurationLoader(['CMS', 'API', 'APP']);
+
+        self::assertSame(['CMS', 'API', 'APP'], $this->getEnvironmentSectionsFromSubject($subject));
+    }
+
+    #[Test]
     public function loadDoesNothingIfGlobalConfigIsInvalid(): void
     {
         $this->unsetEnvFileConfiguration();
@@ -125,6 +139,24 @@ final class SystemConfigurationLoaderTest extends TestCase
         self::assertSame('foo', getenv('PHP_CMS_BASE_BAZ'));
         self::assertSame('baz', getenv('PHP_CMS_BASE_FOO'));
         self::assertSame('baz', getenv('PHP_CMS_BASE_ANOTHER_FOO'));
+    }
+
+    #[Test]
+    public function loadCreatesEnvironmentVariablesForAllConfiguredSections(): void
+    {
+        $this->unsetEnvFileConfiguration();
+        $this->unsetContextConfiguration();
+
+        /* @phpstan-ignore offsetAccess.nonOffsetAccessible */
+        $GLOBALS['TYPO3_CONF_VARS']['API'] = [
+            'base' => [
+                '1' => 'https://api.example.com/',
+            ],
+        ];
+
+        (new SystemConfigurationLoader(['CMS', 'API', 'MISSING']))->load();
+
+        self::assertSame('https://api.example.com/', getenv('PHP_API_BASE_1'));
     }
 
     #[Test]
@@ -243,6 +275,25 @@ final class SystemConfigurationLoaderTest extends TestCase
         self::assertContainsOnlyInstancesOf(ConfigReaderInterface::class, $readers);
 
         return $readers;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getEnvironmentSectionsFromSubject(SystemConfigurationLoader $subject): array
+    {
+        $reflection = new \ReflectionObject($subject);
+        $property = $reflection->getProperty('environmentSections');
+        $environmentSections = $property->getValue($subject);
+
+        self::assertIsArray($environmentSections);
+
+        foreach ($environmentSections as $section) {
+            self::assertIsString($section);
+        }
+
+        /** @var string[] $environmentSections */
+        return $environmentSections;
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
`SystemConfigurationLoader` only ever bridged the `CMS` section of
  `$GLOBALS['TYPO3_CONF_VARS']` to `PHP_CMS_*` environment variables — every
  other top-level section (`API`, `APP`, custom sections, ...) had no way to
  reach the environment, forcing consumers to hand-roll their own putenv()
  loop in `additional.php`.

  This adds an optional constructor parameter, `$environmentSections`,
  defaulting to `['CMS']`. `processLoadedData()` now loops over the
  configured sections instead of a single hardcoded key.

      new SystemConfigurationLoader(['CMS', 'API', 'APP']);

  Backwards compatible: existing zero-arg call sites keep bridging only
  `CMS`, unchanged.

  The default stays `['CMS']` on purpose rather than bridging every section
  automatically — most other sections (`DB`, `BE`, extension configuration)
  can hold credentials, and dumping those into the process environment is a
  bigger exposure surface than a nested PHP array (phpinfo(), $_ENV dumps in
  logs/exception traces, child-process inheritance, docker inspect). Callers
  opt in per section, explicitly.

  Also documented in the README, including a warning about not bridging
  secret-bearing sections.

  Tests added for: default behavior unchanged, custom section list accepted,
  and `load()` actually bridging an additional section while silently
  skipping ones not present in the merged config.